### PR TITLE
Kom4 bacros sql optimizavimas

### DIFF
--- a/backend/controllers/recipeController.js
+++ b/backend/controllers/recipeController.js
@@ -62,15 +62,19 @@ exports.getAllRecipesHandler = async (req, res, next) => {
       });
     }
 
-    const result = await Promise.all(
-      recipes.map(async (recipe) => {
-        const calories = await getAllMacros(recipe.id);
-        return {
-          ...recipe,
-          calories: calories[0]?.calories || 0,
-        };
-      })
-    );
+    // Surenkame visų receptų ID į masyvą
+    const ids = recipes.map(recipe => recipe.id);
+
+    // Gauname visų receptų makroelementus viena užklausa
+    const macrosList = await getAllMacros(ids);
+    // Sudarome žemėlapį pagal recipe_id
+    const macrosMap = new Map(macrosList.map(m => [m.recipe_id, m]));
+
+    // Susiejame makroelementus su receptais
+    const result = recipes.map(recipe => ({
+      ...recipe,
+      calories: macrosMap.get(recipe.id)?.calories || 0,
+    }));
 
     res.status(200).json({
       status: "success",

--- a/backend/models/recipeModel.js
+++ b/backend/models/recipeModel.js
@@ -44,8 +44,9 @@ exports.searchRecipes = async (filters) => {
       ${type ? sql`AND r.type = ${type}` : sql``}
       ${preparation_time ? sql`AND r.preparation_time = ${preparation_time}` : sql``}
       ${servings ? sql`AND r.servings = ${servings}` : sql``}
-      ${product
-      ? sql`
+      ${
+        product
+          ? sql`
         AND EXISTS (
           SELECT 1
           FROM recipes_products rp
@@ -57,10 +58,11 @@ exports.searchRecipes = async (filters) => {
           )
         )
       `
-      : sql``
-    }
-      ${q
-      ? sql`
+          : sql``
+      }
+      ${
+        q
+          ? sql`
         AND (
           similarity(r.title, ${q}) > 0.2
           OR r.title ILIKE ${`%${q}%`}
@@ -78,16 +80,23 @@ exports.searchRecipes = async (filters) => {
           )
         )
       `
-      : sql``
-    }
+          : sql``
+      }
     )
     SELECT * FROM recipe_scores r
-    ${order === 'new' ? sql`ORDER BY r.id DESC` : 
-      order === 'old' ? sql`ORDER BY r.id ASC` : 
-      order === 'title' ? sql`ORDER BY r.title ASC` : 
-      order === 'asc' ? sql`ORDER BY r.id ASC` :
-      order === 'desc' ? sql`ORDER BY r.id DESC` :
-      sql`ORDER BY r.similarity_score DESC`}
+    ${
+      order === "new"
+        ? sql`ORDER BY r.id DESC`
+        : order === "old"
+          ? sql`ORDER BY r.id ASC`
+          : order === "title"
+            ? sql`ORDER BY r.title ASC`
+            : order === "asc"
+              ? sql`ORDER BY r.id ASC`
+              : order === "desc"
+                ? sql`ORDER BY r.id DESC`
+                : sql`ORDER BY r.similarity_score DESC`
+    }
     LIMIT ${limit}
     OFFSET ${offset}
 `;
@@ -100,8 +109,9 @@ exports.searchRecipes = async (filters) => {
     ${type ? sql`AND r.type = ${type}` : sql``}
     ${preparation_time ? sql`AND r.preparation_time = ${preparation_time}` : sql``}
     ${servings ? sql`AND r.servings = ${servings}` : sql``}
-    ${product
-      ? sql`
+    ${
+      product
+        ? sql`
       AND EXISTS (
         SELECT 1 
         FROM recipes_products rp
@@ -113,10 +123,11 @@ exports.searchRecipes = async (filters) => {
         )
       )
     `
-      : sql``
+        : sql``
     }
-    ${q
-      ? sql`
+    ${
+      q
+        ? sql`
       AND (
         similarity(r.title, ${q}) > 0.2
         OR r.title ILIKE ${`%${q}%`}
@@ -134,7 +145,7 @@ exports.searchRecipes = async (filters) => {
         )
       )
     `
-      : sql``
+        : sql``
     }
   `;
   const [recipes, [{ total }]] = await Promise.all([searchQuery, countQuery]);
@@ -285,11 +296,14 @@ exports.deleteRecipe = async (id) => {
   });
 };
 
-exports.getAllMacros = async (id) => {
+exports.getAllMacros = async (ids) => {
+  // Užtikriname, kad ids visada būtų masyvas
+  if (!Array.isArray(ids)) ids = [ids];
   //macros recipe calculator
 
   const macros = await sql`
    SELECT 
+   recipes.id AS recipe_id,
    ROUND(COALESCE(SUM((recipes_products.amount::NUMERIC / 100) * products.calories), 0)::NUMERIC, 0) AS calories,
    ROUND(COALESCE(SUM((recipes_products.amount::NUMERIC / 100) * products.fats), 0)::NUMERIC, 1) AS fats,
    ROUND(COALESCE(SUM((recipes_products.amount::NUMERIC / 100) * products.carbohydrates), 0)::NUMERIC, 1) AS carbohydrates,
@@ -297,7 +311,8 @@ exports.getAllMacros = async (id) => {
    FROM recipes
    JOIN recipes_products ON recipes_products.recipe_id = recipes.id
    JOIN products ON products.id = recipes_products.product_id
-   WHERE recipes.id = ${id};
+   WHERE recipes.id = ANY(${ids})
+   GROUP BY recipes.id;
    `;
 
   return macros;


### PR DESCRIPTION
ispresta klaida, kai startuojant aplikacija sukuriama daug jungciu su postgreeSQL serveriu. Problema buvo kaloriju ir macroelementu skaiciavime. Kiekvienam receptui buvo siunciama atskira uzklausa ir sukuriama atskira jungtis su postgre serveriu. Dabar vykdoma tik viena uzklausa formuojant masyva. Kadangi dabar i uzklausa reikia siusti masyva o ne kintamaji ir as tingejau ieskoti/keisti  per visa koda idetas  if (!Array.isArray(ids)) ids = [ids];  kad butu garantuotai siunciamas masyvas. Taip pat as neteisingai interpretavau pool darba ir maniau kad backend pool pagalba suformuoja viena jungti, o uzklausos formuoja eile. Is tikruju kai uzklausu yra daug vienu metu, formuojama daug aktyviu jungciu kiek leidzia pool_max reiksme, ivykdyti sql kabo laukimo rezime ir laukia ar nebus pakartos uzklausos (IDLE rysiai) ir jie irgi kartu su aktyviom jungtim rezervuoja vieta poole. Todel gal butu sveika backend .env apriboti IDLE laukimo laika. Siulau patestuoti reiksme DB_POOL_IDLE_TIMEOUT = 5   P.s. eslint graziai suformatavo ir kazkodel rodo daug pakeitimu. realiai faile pakeista keleta eiluciu.